### PR TITLE
feat: allow using local images

### DIFF
--- a/docker2appimage
+++ b/docker2appimage
@@ -186,7 +186,9 @@ then
         exit 1
     fi
 else
-    docker pull --quiet "$docker_object"
+    if ! docker image inspect "$docker_object" >/dev/null 2>/dev/null; then
+        docker pull --quiet "$docker_object"
+    fi
     fetch_exec image "$docker_object"
     container_id=$(docker container create "$docker_object")
     docker export "$container_id" > "$tarball"


### PR DESCRIPTION
Fixes #6.

Previously if a user tried to use a locally-built image (that was not in Docker Hub), the build would fail.